### PR TITLE
Provinz-Erweiterung

### DIFF
--- a/DefaultMap.java
+++ b/DefaultMap.java
@@ -31,17 +31,24 @@ public class DefaultMap extends Map
          * Hier werden später sämtliche Provinzen der Standard-Map erstellt.
          * Dies funktioniert folgendermassen:
          * 
-         * Province <Name> = new Province(<Anzahl Sterne>,"<Anzeigename>");
+         * nextProvinces = new int[<Anzahl angrenzende Provinzen>];
+         * <Zuweisung der angrenzenden Provinzen>
+         * Province <Name> = new Province(<Provinz-ID>,<Kontinent-ID>,<Anzahl Sterne>,"<Anzeigename>",nextProvinces);
          * addObject(<Name>,<x-Position>,<y-Position>);
          * 
          * Zwei Provinzen sind bereits als Beispiel erstellt.
-         * Muss später ggf. korrigiert werden!
+         * Muss später auf jeden Fall korrigiert werden!
          */
+        int[] neighbours;
 
-        Province Irkutsk = new Province(1,"Irkutsk");
-        addObject(Irkutsk,1000,100);
+        neighbours = new int[1];
+        neighbours[0] = 2;        
+        Province Mongolei = new Province(1,1,1,"Mongolei",neighbours);
+        addObject(Mongolei,1000,100);
 
-        Province China = new Province(2,"China");
+        neighbours = new int[1];
+        neighbours[0] = 1;
+        Province China = new Province(2,1,2,"China",neighbours);
         addObject(China,1000,350);
     }
 }

--- a/Province.java
+++ b/Province.java
@@ -9,8 +9,11 @@ import greenfoot.*;  // (World, Actor, GreenfootImage, Greenfoot and MouseInfo)
 public class Province extends Actor
 {
     private int stars = 1;
+    private int provinceID;
     private String displayName;
-    private String owner;
+    private int owner;
+    private int[] nextProvinces;
+    private int continentID;
 
     /**
      * leere Act-Methode
@@ -18,14 +21,22 @@ public class Province extends Actor
      */
     public void act() 
     {
-
+        // GruenerWal war hier :3
     }
 
     // Konstruktor, benötigt Sterne
-    public Province(int s, String d)
+    public Province(int i1, int i2, int i3, String s1, int[] ia1)
     {
-        stars = s;
-        displayName = d;
+        provinceID = i1;
+        continentID = i2;
+        stars = i3;
+        displayName = s1;
+        nextProvinces = new int[ia1.length];
+                
+        for ( int z1 = 0; z1 < ia1.length; z1++)
+        {
+            nextProvinces[z1] = ia1[z1];
+        }
     }
 
     // Liefert die Sterne als Integer
@@ -34,22 +45,40 @@ public class Province extends Actor
         return stars;
     }
 
-    // Setzt die Sterne, benötigt Integer
-    public void setStars(int s)
+    // Liefert die Provinz-ID als Integer
+    public int getProvinceID()
     {
-        s = stars;
+        return provinceID;
+    }
+
+    // Liefert den Anzeigenamen als String
+    public String getDisplayName()
+    {
+        return displayName;
     }
 
     // Liefert den Owner als String
-    public String getOwner()
+    public int getOwner()
     {
         return owner;
     }
-
-    // Setzt den Owner, benötigt String
-    public void setOwner(String o)
+            
+    // Liefert angrenzende Provinzen als Integer-Array
+    public int[] getNextProvinces()
     {
-        o = owner;
+        return nextProvinces;
+    }
+    
+    // Liefert die Kontinent-ID als Integer
+    public int getContinentID()
+    { 
+        return continentID;
     }
 
+    // Setzt den Owner, benötigt String
+    public void setOwner(int o)
+    {
+        owner = o;
+    }
+    
 }


### PR DESCRIPTION
Provinz-Klasse um ein Array für angrenzende Provinzen sowie Kontinent-ID erweitert und aufgeräumt.
Unnötige set-Methoden wurden entfernt.
DefaultMap-Klasse wurde an Änderungen angepasst.
