### PR TITLE
Menü Hintergrundbild Darstellung

### DIFF
--- a/Colours.java
+++ b/Colours.java
@@ -39,6 +39,7 @@ public class Colours extends World implements ButtonEvent
     {    
 
         super(x, y, z); 
+        setBackground(Start_Load.backgroundImage);
         addObject(schwarz, 50, 30);
         addObject ( blau, 170, 30);
         addObject ( grün, 280, 30);

--- a/Map.java
+++ b/Map.java
@@ -23,6 +23,7 @@ public class Map extends World implements ButtonEvent
     public Map( int[] bunt, int zahl , String [] name)
     {
         super (1600,900,1);
+        setBackground(Start_Load.backgroundImage);
         colour = new int[zahl];
         pn = new String[zahl];        
         for (int i=0; i<zahl; i++)

--- a/Start_Load.java
+++ b/Start_Load.java
@@ -8,7 +8,7 @@ import greenfoot.*;  // (World, Actor, GreenfootImage, Greenfoot and MouseInfo)
  */
 public class Start_Load extends World implements ButtonEvent 
 {
-    static String backgroundImage = "backgroundLight.png" // Gibt an, welches Bild in allen Menüs als Hintergrund gewählt werden soll.
+    static String backgroundImage = "backgroundLight.png"; // Gibt an, welches Bild in allen Menüs als Hintergrund gewählt werden soll.
     // Light Theme: "backgroundLight.png"
     // Dark Theme: "backgroundDark.png"
     

--- a/Start_Load.java
+++ b/Start_Load.java
@@ -8,7 +8,11 @@ import greenfoot.*;  // (World, Actor, GreenfootImage, Greenfoot and MouseInfo)
  */
 public class Start_Load extends World implements ButtonEvent 
 {
-     Button chulien = new Button("Neues Spiel", 16 , this);
+    static String backgroundImage = "backgroundLight.png" // Gibt an, welches Bild in allen Menüs als Hintergrund gewählt werden soll.
+    // Light Theme: "backgroundLight.png"
+    // Dark Theme: "backgroundDark.png"
+    
+    Button chulien = new Button("Neues Spiel", 16 , this);
      
     /**
      * Constructor for objects of class Start_Load.
@@ -18,24 +22,25 @@ public class Start_Load extends World implements ButtonEvent
     {    
         // Create a new world with 600x400 cells with a cell size of 1x1 pixels.
         super(1600, 900, 1); 
+        setBackground(backgroundImage);
         chulien.setSize(100,50);
         addObject (chulien, (1600-chulien.getWidth())/2, (900-chulien.getHeight())/2);
-	}
-	public void buttonClicked ( Button b)
-	{
-	    
-	   if ( b  == chulien)
-	   {
-	       World chean = new Colours (1600, 900, 1);
-	       Greenfoot.setWorld(chean);
-	       
-	   }
-	}
-	
-	
-	public void Load()
-	{
-	    
-	}
+    }
+    public void buttonClicked ( Button b)
+    {
+        
+       if ( b  == chulien)
+       {
+           World chean = new Colours (1600, 900, 1);
+           Greenfoot.setWorld(chean);
+           
+       }
+    }
+    
+    
+    public void Load()
+    {
+        
+    }
 }
 


### PR DESCRIPTION
Sorgt dafür, dass das Hintergrundbild von Julien auf allen Menü Bildschirmen angezeigt wird.
Solltet ihr statt dem Light-Theme das Dark-Theme eher mögen, können wir später in der Start_Load Klasse das Hintergrundbild aller Menü-Bildschirme zentral ändern.
